### PR TITLE
Open files in binary mode

### DIFF
--- a/django_filebased_email_backend_ng/backend.py
+++ b/django_filebased_email_backend_ng/backend.py
@@ -38,7 +38,7 @@ class EmailBackend(BaseEmailBackend):
                         or '.%s' % DEFAULT_ATTACHMENT_MIME_TYPE,
                 ))
 
-                with open(filename, 'w') as f:
+                with open(filename, 'wb') as f:
                     f.write(content.encode('utf8'))
 
             # Write out attachments
@@ -53,5 +53,5 @@ class EmailBackend(BaseEmailBackend):
                     mimetypes.guess_extension(mimetype) or '.txt',
                 ))
 
-                with open(filename, 'w') as f:
+                with open(filename, 'wb') as f:
                     f.write(content)


### PR DESCRIPTION
For the alternatives we're handling encoding so should just be writing bytes, and for the attachments we should definitely use binary mode to respect the format of the attachment.

This fixes the filebased backend on Python 3 as well.