### PR TITLE
Aggregate files per usage to allow multiple send_mail() calls

### DIFF
--- a/django_filebased_email_backend_ng/backend.py
+++ b/django_filebased_email_backend_ng/backend.py
@@ -1,6 +1,8 @@
 from __future__ import print_function
 
 import os
+import hashlib
+import inspect
 import shutil
 import mimetypes
 
@@ -10,20 +12,31 @@ from django.core.mail.backends.base import BaseEmailBackend
 
 class EmailBackend(BaseEmailBackend):
     def send_messages(self, messages):
-        try:
-            shutil.rmtree(settings.EMAIL_FILE_PATH)
-        except OSError:
-            pass
+        base_dir = settings.EMAIL_FILE_PATH
 
-        os.makedirs(settings.EMAIL_FILE_PATH)
+        # Files will be stored in a dir which name is calculated
+        # with inspection of where this method is called from.
+        #
+        # Knowing that a same function calling send_mail() multiple times
+        # will have the same frame stack,
+        # the emails sent by a same usage will be aggregated in a unique folder
+        usage_aggregation_dir = hashlib.sha1(str(
+            inspect.getouterframes(inspect.currentframe())
+        ).encode('utf-8')).hexdigest()
 
-        for idx, message in enumerate(messages):
-            base = os.path.join(settings.EMAIL_FILE_PATH, '%s' % idx)
+        # we can now safely delete everything in base dir
+        # except usage aggregation folder
+        for d in os.listdir(base_dir):
+            if d != usage_aggregation_dir:
+                shutil.rmtree(os.path.join(base_dir, d), ignore_errors=True)
 
-            os.makedirs(base)
+        for message in messages:
+            message_dir = '__'.join(message.to).replace('@', '_AT_')
+            target_dir = os.path.join(base_dir, usage_aggregation_dir, message_dir)
+            os.makedirs(target_dir)
 
             # Write out raw email
-            with open(os.path.join(base, 'raw.log'), 'w') as f:
+            with open(os.path.join(target_dir, 'raw.log'), 'w') as f:
                 print('%s' % message.message().as_string(), file=f)
                 print('-' * 79, file=f)
 
@@ -32,7 +45,7 @@ class EmailBackend(BaseEmailBackend):
             for idx, alternative in enumerate(alternatives):
                 content, mimetype = alternative
 
-                filename = os.path.join(base, 'alternative-%d%s' % (
+                filename = os.path.join(target_dir, 'alternative-%d%s' % (
                     idx,
                     mimetypes.guess_extension(mimetype)
                         or '.%s' % DEFAULT_ATTACHMENT_MIME_TYPE,
@@ -48,7 +61,7 @@ class EmailBackend(BaseEmailBackend):
                 if mimetype is None:
                     mimetype = DEFAULT_ATTACHMENT_MIME_TYPE
 
-                filename = os.path.join(base, 'attachment-%d%s' % (
+                filename = os.path.join(target_dir, 'attachment-%d%s' % (
                     idx,
                     mimetypes.guess_extension(mimetype) or '.txt',
                 ))


### PR DESCRIPTION
I sometimes need to call `send_mail` multiple times to send different emails to different users, and i want to debug all emails at once. I think the easiest way to achieve this is to avoid deleting the whole folder and timestamp subfolders instead of iterating the name.